### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -19,15 +19,15 @@ jobs:
   opentofu:
     runs-on: ubuntu-latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
+    - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
       with:
         aws-region: us-east-2
 
         # TODO This needs to be updated to your actual values. We should add a `yq` command that adds this as one of the steps in the initial README.
         role-to-assume: arn:aws:iam::999999999999:role/github-actions-dev-tf-Role-REDACTED
 
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
       id: cache
       with:
         path: |
@@ -35,7 +35,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
         restore-keys: |
           ${{ runner.os }}-
-    - uses: opentofu/setup-opentofu@v1
+    - uses: opentofu/setup-opentofu@000eeb8522f0572907c393e8151076c205fdba1b
       with:
         tofu_version: 1.8.2
     - id: fmt
@@ -49,7 +49,7 @@ jobs:
     - id: plan
       run: tofu plan -var-file=dev.tfvars -no-color -input=false -compact-warnings -out=plan.file
       continue-on-error: true
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       if: github.event_name == 'pull_request'
       env:
         PLAN: "tofu\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)** added a new **[commit](https://github.com/aws-actions/configure-aws-credentials/commit/7474bc4690e29a8392af63c5b98e7449536d5c3a)** to **[v4.3.1](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1)** Tag on 2025-08-04T23:18:24Z
* **[actions/cache](https://github.com/actions/cache)** added a new **[commit](https://github.com/actions/cache/commit/0400d5f644dc74513175e3cd8d07132dd4860809)** to **[v4.2.4](https://github.com/actions/cache/releases/tag/v4.2.4)** Tag on 2025-08-07T12:47:42Z
* **[actions/github-script](https://github.com/actions/github-script)** added a new **[commit](https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea)** to **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** Tag on 2023-11-17T22:20:07Z
* **[actions/checkout](https://github.com/actions/checkout)** added a new **[commit](https://github.com/actions/checkout/commit/08c6903cd8c0fde910a37f88322edcfb5dd907a8)** to **[v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0)** Tag on 2025-08-11T12:35:28Z
* **[opentofu/setup-opentofu](https://github.com/opentofu/setup-opentofu)** added a new **[commit](https://github.com/opentofu/setup-opentofu/commit/000eeb8522f0572907c393e8151076c205fdba1b)** to **[v1.0.6](https://github.com/opentofu/setup-opentofu/releases/tag/v1.0.6)** Tag on 2025-08-04T12:32:54Z
