### PR TITLE
Enable VPC flow logs to S3

### DIFF
--- a/cluster/flow-logs.tf
+++ b/cluster/flow-logs.tf
@@ -1,0 +1,138 @@
+################################################################################
+# VPC Flow Logs S3 storage
+#
+# The VPC module (main.tf) is configured to deliver flow logs to S3 rather than
+# CloudWatch Logs — S3 is far cheaper for high-volume network flow data. The
+# module creates only the aws_flow_log resource; the destination bucket, the
+# log-delivery bucket policy, and the retention lifecycle live here.
+#
+# Unlike the CloudWatch path there is no IAM role: flow logs are written by the
+# AWS log-delivery service (delivery.logs.amazonaws.com), which is granted
+# access via the bucket policy below. Retaining logs for a full year matches the
+# EKS control-plane log retention (main.tf) and covers the 12-month SOC 2 Type
+# II observation period.
+################################################################################
+
+locals {
+  # With org_name "devopscoop" and cluster_name "project1-dev", this yields
+  # "devopscoop-project1-dev-vpc-flow-logs".
+  flow_logs_bucket = "${var.org_name}-${var.cluster_name}-vpc-flow-logs"
+
+  # How long to retain delivered flow log objects before expiring them.
+  flow_logs_retention_days = 365
+}
+
+resource "aws_s3_bucket" "flow_logs" {
+  bucket = local.flow_logs_bucket
+}
+
+resource "aws_s3_bucket_public_access_block" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Expire delivered flow log objects after the retention window; also clean up
+# any incomplete multipart uploads.
+resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    id     = "expire-flow-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = local.flow_logs_retention_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# Bucket policy granting the VPC Flow Logs delivery service permission to write
+# log files and read the bucket ACL. This is the policy AWS would otherwise add
+# automatically when a flow log is created via the console; the Terraform
+# aws_flow_log resource does not manage it, so we attach it explicitly. The
+# SourceAccount/SourceArn conditions scope delivery to this account's logs and
+# guard against the confused-deputy problem.
+data "aws_iam_policy_document" "flow_logs" {
+  statement {
+    sid       = "AWSLogDeliveryWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.flow_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${local.region}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+
+  statement {
+    sid       = "AWSLogDeliveryAclCheck"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl", "s3:ListBucket"]
+    resources = [aws_s3_bucket.flow_logs.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${local.region}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+  policy = data.aws_iam_policy_document.flow_logs.json
+
+  # The public-access block's block_public_policy setting evaluates bucket
+  # policies as they are applied; create it first so this policy isn't rejected.
+  depends_on = [aws_s3_bucket_public_access_block.flow_logs]
+}

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -183,6 +183,25 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
+  # Capture VPC Flow Logs for all traffic (accepted and rejected) to S3. S3 is
+  # markedly cheaper than CloudWatch Logs for high-volume flow data. The bucket,
+  # its log-delivery policy, and retention lifecycle are defined in
+  # flow-logs.tf; the module only creates the aws_flow_log resource pointing at
+  # that bucket, so the CloudWatch IAM role and log group are disabled here.
+  # Network flow logging supports SOC 2 (CC7.2, System Monitoring) and ISO/IEC
+  # 27001:2022 Annex A 8.15 (Logging) / 8.16 (Monitoring activities), and aids
+  # incident investigation.
+  enable_flow_log                      = true
+  flow_log_destination_type            = "s3"
+  flow_log_destination_arn             = aws_s3_bucket.flow_logs.arn
+  create_flow_log_cloudwatch_iam_role  = false
+  create_flow_log_cloudwatch_log_group = false
+  flow_log_traffic_type                = "ALL"
+
+  # Bill flow logs at the finest granularity (module default is 600s). One-minute
+  # aggregation gives more precise timelines for security investigations.
+  flow_log_max_aggregation_interval = 60
+
   # IPv6
   enable_ipv6                                    = true
   public_subnet_assign_ipv6_address_on_creation  = true


### PR DESCRIPTION
## What

Enable VPC Flow Logs on the cluster VPC, delivered to a dedicated encrypted S3 bucket.

## Why

Network flow logging aids incident investigation and supports SOC 2 (CC7.2, System Monitoring) and ISO/IEC 27001:2022 Annex A 8.15 (Logging) / 8.16 (Monitoring activities) — consistent with the existing EKS control-plane logging config.

S3 is the delivery destination (rather than CloudWatch Logs) because it is far cheaper for high-volume flow data.

## Changes

- **`cluster/main.tf`** — configure the `vpc` module to emit flow logs (`traffic_type = ALL`, 60s aggregation interval) to S3; the CloudWatch IAM role/log group are disabled since they aren't used for the S3 path.
- **`cluster/flow-logs.tf`** (new) — the destination bucket, following `loki.tf`'s conventions:
  - `aws_s3_bucket` named `${org_name}-${cluster_name}-vpc-flow-logs`
  - public-access block + SSE (AES256)
  - lifecycle rule expiring objects after **365 days** (matches the EKS control-plane log retention and the SOC 2 Type II observation window)
  - a bucket policy granting the `delivery.logs.amazonaws.com` service write/ACL access, scoped with `aws:SourceAccount`/`aws:SourceArn` conditions. Required for S3 delivery — the `aws_flow_log` resource doesn't create it (the console does), and there's no IAM role in the S3 path.

## Testing

- `tofu init -backend=false` — modules/providers install cleanly.
- `tofu validate` — **Success! The configuration is valid.**
- `tofu plan` could not be run here (S3 state backend needs AWS credentials, unavailable in this environment). Please review the plan before merging — it should show **creates only** (bucket + supporting resources + one `aws_flow_log` inside `module.vpc`), no destroys/replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)