### PR TITLE
fix: use client-id for ghaups GitHub App token

### DIFF
--- a/.github/workflows/ghaups-daily.yml
+++ b/.github/workflows/ghaups-daily.yml
@@ -43,7 +43,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.GHAUPS_APP_ID }}
+          client-id: ${{ vars.GHAUPS_APP_CLIENT_ID }}
           private-key: ${{ secrets.GHAUPS_APP_PRIVATE_KEY }}
           # Scope the token to only what the PR step needs, instead of inheriting
           # the app installation's full permission set.


### PR DESCRIPTION
The `ghaups daily` workflow fails at the **Generate GitHub App token** step because `vars.GHAUPS_APP_ID` is no longer set — the GitHub App was upgraded to authenticate with a client ID.

This switches the `actions/create-github-app-token` input from the deprecated `app-id`/`GHAUPS_APP_ID` to `client-id`/`GHAUPS_APP_CLIENT_ID`, matching the `ghaups` repo's own workflow. It also clears the `app-id` deprecation warning.

Requires the `GHAUPS_APP_CLIENT_ID` variable and `GHAUPS_APP_PRIVATE_KEY` secret to be available to the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)