### PR TITLE
fix: deny non-HTTPS access to S3 buckets

### DIFF
--- a/cluster/flow-logs.tf
+++ b/cluster/flow-logs.tf
@@ -126,6 +126,29 @@ data "aws_iam_policy_document" "flow_logs" {
       values   = ["arn:aws:logs:${local.region}:${data.aws_caller_identity.current.account_id}:*"]
     }
   }
+
+  # Deny all non-HTTPS access so flow log data is always encrypted in transit.
+  # Log delivery and any log consumers use TLS, so this only blocks misuse.
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.flow_logs.arn,
+      "${aws_s3_bucket.flow_logs.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "flow_logs" {

--- a/cluster/loki.tf
+++ b/cluster/loki.tf
@@ -46,6 +46,44 @@ resource "aws_s3_bucket_public_access_block" "loki" {
   restrict_public_buckets = true
 }
 
+# Deny all non-HTTPS access so log data is always encrypted in transit. Loki
+# (via the AWS SDK) and S3 replication both use TLS, so this only blocks misuse.
+data "aws_iam_policy_document" "loki_https_only" {
+  for_each = local.loki_buckets
+
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.loki[each.key].arn,
+      "${aws_s3_bucket.loki[each.key].arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "loki" {
+  for_each = local.loki_buckets
+
+  bucket = aws_s3_bucket.loki[each.key].id
+  policy = data.aws_iam_policy_document.loki_https_only[each.key].json
+
+  # The public-access block's block_public_policy setting evaluates bucket
+  # policies as they are applied; create it first so this policy isn't rejected.
+  depends_on = [aws_s3_bucket_public_access_block.loki]
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "loki" {
   for_each = local.loki_buckets
 
@@ -182,6 +220,45 @@ resource "aws_s3_bucket_public_access_block" "loki_replica" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+# Same HTTPS-only enforcement as the source buckets. S3 replication delivers
+# over TLS, so denying insecure transport does not affect it.
+data "aws_iam_policy_document" "loki_replica_https_only" {
+  for_each = local.loki_buckets
+
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.loki_replica[each.key].arn,
+      "${aws_s3_bucket.loki_replica[each.key].arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "loki_replica" {
+  for_each = local.loki_buckets
+  provider = aws.replica
+
+  bucket = aws_s3_bucket.loki_replica[each.key].id
+  policy = data.aws_iam_policy_document.loki_replica_https_only[each.key].json
+
+  # The public-access block's block_public_policy setting evaluates bucket
+  # policies as they are applied; create it first so this policy isn't rejected.
+  depends_on = [aws_s3_bucket_public_access_block.loki_replica]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "loki_replica" {


### PR DESCRIPTION
## Summary

Fixes the Vanta test **"S3 buckets allow only HTTPS traffic (AWS)"** by ensuring every S3 bucket defined in this repo has a bucket policy that denies non-TLS requests.

Each added/extended policy contains a `DenyInsecureTransport` statement matching the test's pass criteria: `Effect: Deny`, principal `*`, action `s3:*` (covers object reads), resources covering both the bucket and `arn:aws:s3:::{bucket}/*`, and condition `Bool aws:SecureTransport = false`.

## Changes

- **`cluster/flow-logs.tf`** — the flow-logs bucket already had a policy granting the log-delivery service write access; added a deny statement for insecure transport to it. Log delivery uses TLS, so it is unaffected.
- **`cluster/loki.tf`** — the Loki chunks/ruler buckets had no bucket policy; attached a new HTTPS-only policy to both. Also applied the same policy to the cross-region replica buckets — they're `VantaNoAlert`-tagged (out of Vanta scope) but this keeps them consistent with the sources. Loki (AWS SDK) and S3 replication both use TLS, so nothing breaks.
- Both new `aws_s3_bucket_policy` resources `depends_on` their bucket's public-access block, matching the existing flow-logs pattern.

Not changed: the Terraform state and logging buckets from `trussworks/bootstrap` — verified the underlying trussworks modules (`s3-private-bucket` v8.0.2, `logs` v17.0.0) already include an `enforce-tls-requests-only` deny statement.

## Testing

- `tofu fmt -check` passes on the edited files
- `tofu validate` passes for the `cluster/` configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)