### PR TITLE
Add Brewfile and Arch pkglist.txt for installing required tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repo.
+
+## Package manifests
+
+This repo ships a `Brewfile` (macOS: `brew bundle`) and a `pkglist.txt` (Arch Linux) that install every CLI tool the repo uses. Keep them in sync with the code:
+
+- When you add a tool, script, or a new external command inside an existing script, add the package to BOTH files, with a comment noting what uses it.
+- When a tool stops being used, remove it from both files.
+- Verify package names before adding them: `brew info <formula>` for Homebrew, and the official repos/AUR for Arch. Names differ between ecosystems (e.g. kubectl is Homebrew `kubernetes-cli` but Arch `kubectl`; Homebrew `awscli` is Arch `aws-cli-v2`). If a package is AUR-only, note that in pkglist.txt's header instructions.
+- Update the "Install required packages" section in README.md if the tool list changes.
+- OpenTofu is managed by tenv (which reads `.opentofu-version`) — never add `opentofu` directly to the manifests.

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,36 @@
+# Brewfile for aws-eks-template
+#
+# Installs every CLI tool used or referenced by this repo.
+# Usage: brew bundle
+
+# AWS CLI (`aws`) - README onboarding, update_eks_addons.sh, `aws eks update-kubeconfig`
+brew "awscli"
+
+# AWS SSO CLI (`aws-sso`) - README onboarding; short-lived credentials instead of `aws configure`
+brew "aws-sso-cli"
+
+# tenv - version manager that installs/pins OpenTofu (`tofu`) from .opentofu-version.
+# Per the README, do NOT install opentofu directly; tenv provides the `tofu` binary.
+# Used by upgrade_opentofu.sh and for `tofu init/plan/apply` in bootstrap/ and cluster/.
+brew "tenv"
+
+# jq - JSON parsing in cluster/update_eks_addons.sh
+brew "jq"
+
+# kubectl - connecting to the cluster with the kubeconfig from `aws eks update-kubeconfig`
+brew "kubernetes-cli"
+
+# git - fork/subtree workflow in the README, quickstart.sh
+brew "git"
+
+# zizmor - GitHub Actions workflow auditing, referenced in .github/workflows/opentofu-aws-eks.yml
+brew "zizmor"
+
+# bash - all repo scripts use `#!/usr/bin/env bash`
+brew "bash"
+
+# perl - in-place substitutions in quickstart.sh
+brew "perl"
+
+# Not available via Homebrew:
+# - Argdown CLI (renders docs/fork_vs_subtree.argdown): npm install -g @argdown/cli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -9,15 +9,29 @@ This repo can be used to build a production-ready AWS EKS Kubernetes cluster. It
 
 ## Onboarding
 
-### Install the AWS CLI
+### Install required packages
 
-Follow the [official AWS CLI installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) for your operating system.
+This repo ships package manifests that install every CLI tool it uses (`aws`, `aws-sso`, `tenv`, `jq`, `kubectl`, `git`, `zizmor`, `bash`, `perl`):
 
-> **Warning:** Do not use `aws configure` to set up credentials. The official AWS CLI sprinkles long-lived access keys in plaintext across `~/.aws/credentials` - it's like the Easter Bunny for malicious actors, scripts, and AI agents. Use AWS SSO CLI (below) instead — it handles short-lived credentials automatically without writing secrets to disk.
+- macOS, using [Homebrew](https://brew.sh/) and the `Brewfile`:
+
+  ```shell
+  brew bundle
+  ```
+
+- Arch Linux, using the `pkglist.txt`. This requires an AUR helper such as [yay](https://github.com/Jguer/yay) or [paru](https://github.com/Morganamilo/paru), because `tenv-bin` and `aws-sso-cli-bin` are AUR packages:
+
+  ```shell
+  grep -vE '^(#|$)' pkglist.txt | yay -S --needed -
+  ```
+
+On other operating systems, install the tools listed above manually.
 
 ### Install AWS SSO CLI
 
 Install [AWS SSO CLI](https://synfinatic.github.io/aws-sso-cli/latest/demos/) using the method appropriate for your OS (Homebrew, package manager, or binary download).
+
+> **Warning:** Do not use `aws configure` to set up credentials. The official AWS CLI sprinkles long-lived access keys in plaintext across `~/.aws/credentials` - it's like the Easter Bunny for malicious actors, scripts, and AI agents. Use AWS SSO CLI instead — it handles short-lived credentials automatically without writing secrets to disk.
 
 Run `aws-sso` for the first time to generate a config. It will prompt you interactively:
 

--- a/pkglist.txt
+++ b/pkglist.txt
@@ -1,0 +1,40 @@
+# Arch Linux package list for aws-eks-template — the pacman/AUR equivalent of
+# the Brewfile. Installs every CLI tool used or referenced by this repo.
+#
+# Requires an AUR helper (yay or paru) because tenv-bin and aws-sso-cli-bin
+# are AUR packages; everything else is in the official repos.
+#
+# Usage:
+#   grep -vE '^(#|$)' pkglist.txt | yay -S --needed -
+#   grep -vE '^(#|$)' pkglist.txt | paru -S --needed -
+
+# AWS CLI v2 (`aws`) — extra/aws-cli-v2 (extra/aws-cli is the legacy v1)
+aws-cli-v2
+
+# AWS SSO CLI (`aws-sso`) — AUR; README onboarding, short-lived credentials
+aws-sso-cli-bin
+
+# tenv — AUR; provides `tofu` from .opentofu-version. Per the README, do NOT
+# install opentofu directly.
+tenv-bin
+
+# jq — JSON parsing in cluster/update_eks_addons.sh
+jq
+
+# kubectl — connecting to the cluster with the kubeconfig from `aws eks update-kubeconfig`
+kubectl
+
+# git — fork/subtree workflow in the README, quickstart.sh
+git
+
+# zizmor — GitHub Actions workflow auditing, referenced in .github/workflows/opentofu-aws-eks.yml
+zizmor
+
+# bash — all repo scripts use `#!/usr/bin/env bash`
+bash
+
+# perl — in-place substitutions in quickstart.sh
+perl
+
+# Not packaged for Arch:
+# - Argdown CLI (renders docs/fork_vs_subtree.argdown): npm install -g @argdown/cli


### PR DESCRIPTION
## Summary

- Add a `Brewfile` installing every CLI tool this repo uses or references (`aws`, `aws-sso`, `tenv`, `jq`, `kubectl`, `git`, `zizmor`, `bash`, `perl`) via `brew bundle`
- Add an Arch Linux `pkglist.txt` mirroring the Brewfile tool-for-tool, installable with `grep -vE '^(#|$)' pkglist.txt | yay -S --needed -` (or `paru`)
- Document both manifests in a new "Install required packages" subsection at the top of the README's Onboarding section
- Remove the manual "Install the AWS CLI" section (covered by the manifests) and move its `aws configure` credentials warning into the "Install AWS SSO CLI" section

## Notes

- Per the README's guidance, the manifests install `tenv` rather than OpenTofu directly; tenv provides `tofu` pinned by `.opentofu-version`
- Arch package names were verified against the live package database and AUR RPC: AWS CLI v2 is `aws-cli-v2` (`aws-cli` is legacy v1), `zizmor` is in extra, and `tenv`/`aws-sso-cli` exist only as AUR `-bin` packages — hence the AUR-helper requirement
- The Argdown CLI (renders `docs/fork_vs_subtree.argdown`) isn't packaged for Homebrew or Arch; both manifests note the `npm install -g @argdown/cli` alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)