### PR TITLE
Stop replicating log buckets cross-region; mark them VantaNoAlert

### DIFF
--- a/cluster/flow-logs.tf
+++ b/cluster/flow-logs.tf
@@ -24,6 +24,17 @@ locals {
 
 resource "aws_s3_bucket" "flow_logs" {
   bucket = local.flow_logs_bucket
+
+  # The VantaNoAlert tag deactivates the resource in Vanta (marks it out of
+  # scope), with the tag value recorded as the reason. Without it, Vanta's
+  # backup/replication test flags this bucket as needing cross-region
+  # replication, even though flow logs are diagnostic network telemetry that
+  # does not warrant a DR copy — expired objects are simply re-delivered.
+  # Note this takes the bucket out of scope for ALL Vanta tests, not just the
+  # replication one.
+  tags = {
+    VantaNoAlert = "VPC flow log storage - diagnostic network telemetry that does not need cross-region replication"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "flow_logs" {

--- a/cluster/loki.tf
+++ b/cluster/loki.tf
@@ -23,16 +23,24 @@ locals {
     chunks = "${local.loki_bucket_prefix}-loki-chunks"
     ruler  = "${local.loki_bucket_prefix}-loki-ruler"
   }
-
-  # How long to keep superseded (noncurrent) object versions before expiring
-  # them. Applies to both source and replica buckets.
-  loki_noncurrent_version_expiration_days = 30
 }
 
 resource "aws_s3_bucket" "loki" {
   for_each = local.loki_buckets
 
   bucket = each.value
+
+  # These buckets hold operational log data and intentionally have no
+  # cross-region replica — the compliance-relevant logs (VPC flow logs, EKS
+  # control-plane logs) are the ones retained long-term, not Loki's. The
+  # VantaNoAlert tag deactivates the resource in Vanta (marks it out of scope),
+  # with the tag value recorded as the reason. Without it, Vanta's
+  # backup/replication test flags these buckets as needing replication. Note
+  # this takes the bucket out of scope for ALL Vanta tests, not just the
+  # replication one.
+  tags = {
+    VantaNoAlert = "Loki operational log storage - does not need cross-region replication"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "loki" {
@@ -47,7 +55,7 @@ resource "aws_s3_bucket_public_access_block" "loki" {
 }
 
 # Deny all non-HTTPS access so log data is always encrypted in transit. Loki
-# (via the AWS SDK) and S3 replication both use TLS, so this only blocks misuse.
+# (via the AWS SDK) uses TLS, so this only blocks misuse.
 data "aws_iam_policy_document" "loki_https_only" {
   for_each = local.loki_buckets
 
@@ -96,38 +104,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "loki" {
   }
 }
 
-# Versioning is a hard requirement for S3 replication, on both the source and
-# the destination buckets.
-resource "aws_s3_bucket_versioning" "loki" {
-  for_each = local.loki_buckets
-
-  bucket = aws_s3_bucket.loki[each.key].id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-# Versioning retains every overwritten/deleted object version indefinitely. Loki
-# rewrites and compacts objects routinely, so expire noncurrent versions to
-# bound storage cost; the current (live) version is never affected.
+# Clean up incomplete multipart uploads so partial chunk writes don't linger and
+# accrue storage cost. Loki manages its own object retention via compaction, so
+# there is no object-expiration rule here.
 resource "aws_s3_bucket_lifecycle_configuration" "loki" {
   for_each = local.loki_buckets
 
   bucket = aws_s3_bucket.loki[each.key].id
 
-  # Lifecycle rules require versioning to already be configured.
-  depends_on = [aws_s3_bucket_versioning.loki]
-
   rule {
-    id     = "expire-noncurrent-versions"
+    id     = "abort-incomplete-multipart-uploads"
     status = "Enabled"
 
     filter {}
-
-    noncurrent_version_expiration {
-      noncurrent_days = local.loki_noncurrent_version_expiration_days
-    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
@@ -182,231 +171,9 @@ module "loki_irsa" {
   }
 }
 
-################################################################################
-# Cross-region replication
-#
-# Each Loki bucket is replicated to an identically-structured bucket in
-# var.replica_region for redundancy against a regional failure. Loki itself only
-# ever reads/writes the source buckets (above); the replicas are a passive DR
-# copy, so they are not added to the loki IRSA policy.
-################################################################################
-
-# Destination buckets live in the replica region. They mirror the source
-# buckets' encryption, public-access block, and versioning settings.
-resource "aws_s3_bucket" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = "${each.value}-replica"
-
-  # The VantaNoAlert tag deactivates the resource in Vanta (marks it out of
-  # scope), with the tag value recorded as the reason. Without it, Vanta's
-  # backup/replication test flags these buckets as needing replication of
-  # their own, even though they exist only as replication destinations.
-  # Note this takes the bucket out of scope for ALL Vanta tests, not just the
-  # replication one.
-  tags = {
-    VantaNoAlert = "Replication destination for ${each.value} - this bucket is the DR copy and does not itself need replication"
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = aws_s3_bucket.loki_replica[each.key].id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-# Same HTTPS-only enforcement as the source buckets. S3 replication delivers
-# over TLS, so denying insecure transport does not affect it.
-data "aws_iam_policy_document" "loki_replica_https_only" {
-  for_each = local.loki_buckets
-
-  statement {
-    sid     = "DenyInsecureTransport"
-    effect  = "Deny"
-    actions = ["s3:*"]
-    resources = [
-      aws_s3_bucket.loki_replica[each.key].arn,
-      "${aws_s3_bucket.loki_replica[each.key].arn}/*",
-    ]
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["false"]
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = aws_s3_bucket.loki_replica[each.key].id
-  policy = data.aws_iam_policy_document.loki_replica_https_only[each.key].json
-
-  # The public-access block's block_public_policy setting evaluates bucket
-  # policies as they are applied; create it first so this policy isn't rejected.
-  depends_on = [aws_s3_bucket_public_access_block.loki_replica]
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = aws_s3_bucket.loki_replica[each.key].id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_s3_bucket_versioning" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = aws_s3_bucket.loki_replica[each.key].id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-# Same noncurrent-version expiry as the source buckets. Replication writes new
-# versions (and delete markers) here too, so the replicas accumulate noncurrent
-# versions just as the sources do.
-resource "aws_s3_bucket_lifecycle_configuration" "loki_replica" {
-  for_each = local.loki_buckets
-  provider = aws.replica
-
-  bucket = aws_s3_bucket.loki_replica[each.key].id
-
-  depends_on = [aws_s3_bucket_versioning.loki_replica]
-
-  rule {
-    id     = "expire-noncurrent-versions"
-    status = "Enabled"
-
-    filter {}
-
-    noncurrent_version_expiration {
-      noncurrent_days = local.loki_noncurrent_version_expiration_days
-    }
-
-    abort_incomplete_multipart_upload {
-      days_after_initiation = 7
-    }
-  }
-}
-
-# Role assumed by the S3 service to copy objects from the source buckets to the
-# replicas.
-data "aws_iam_policy_document" "loki_replication_assume" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "loki_replication" {
-  name               = "${local.name}-loki-s3-replication"
-  assume_role_policy = data.aws_iam_policy_document.loki_replication_assume.json
-}
-
-# Source buckets are SSE-S3 (AES256), so no KMS decrypt/encrypt permissions are
-# required here. Switching either side to SSE-KMS would also require kms:* grants
-# and an encryption_configuration block on the destination below.
-data "aws_iam_policy_document" "loki_replication" {
-  statement {
-    sid = "ReadSourceBuckets"
-    actions = [
-      "s3:GetReplicationConfiguration",
-      "s3:ListBucket",
-    ]
-    resources = [for b in aws_s3_bucket.loki : b.arn]
-  }
-
-  statement {
-    sid = "ReadSourceObjects"
-    actions = [
-      "s3:GetObjectVersionForReplication",
-      "s3:GetObjectVersionAcl",
-      "s3:GetObjectVersionTagging",
-    ]
-    resources = [for b in aws_s3_bucket.loki : "${b.arn}/*"]
-  }
-
-  statement {
-    sid = "WriteReplicaObjects"
-    actions = [
-      "s3:ReplicateObject",
-      "s3:ReplicateDelete",
-      "s3:ReplicateTags",
-    ]
-    resources = [for b in aws_s3_bucket.loki_replica : "${b.arn}/*"]
-  }
-}
-
-resource "aws_iam_policy" "loki_replication" {
-  name        = "${local.name}-loki-s3-replication"
-  description = "Allows S3 to replicate the Loki buckets to the replica region"
-  policy      = data.aws_iam_policy_document.loki_replication.json
-}
-
-resource "aws_iam_role_policy_attachment" "loki_replication" {
-  role       = aws_iam_role.loki_replication.name
-  policy_arn = aws_iam_policy.loki_replication.arn
-}
-
-resource "aws_s3_bucket_replication_configuration" "loki" {
-  for_each = local.loki_buckets
-
-  # Replication can only be configured once versioning is enabled on both ends.
-  depends_on = [
-    aws_s3_bucket_versioning.loki,
-    aws_s3_bucket_versioning.loki_replica,
-  ]
-
-  role   = aws_iam_role.loki_replication.arn
-  bucket = aws_s3_bucket.loki[each.key].id
-
-  rule {
-    id     = "replicate-all"
-    status = "Enabled"
-
-    destination {
-      bucket        = aws_s3_bucket.loki_replica[each.key].arn
-      storage_class = "STANDARD"
-    }
-  }
-}
-
 output "loki_bucket_names" {
   description = "Loki S3 bucket names. Set these as loki.storage.bucketNames.{chunks,ruler} in the loki Helm values in fluxcd-template."
   value       = { for k, b in aws_s3_bucket.loki : k => b.id }
-}
-
-output "loki_replica_bucket_names" {
-  description = "Cross-region replica Loki S3 bucket names (DR copies in var.replica_region)."
-  value       = { for k, b in aws_s3_bucket.loki_replica : k => b.id }
 }
 
 output "loki_role_arn" {

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -9,17 +9,6 @@ provider "aws" {
   }
 }
 
-# Second region, used only for the cross-region replicas of the Loki S3
-# buckets (see loki.tf). Reference it with `provider = aws.replica`.
-provider "aws" {
-  alias  = "replica"
-  region = var.replica_region
-
-  default_tags {
-    tags = local.tags
-  }
-}
-
 data "aws_caller_identity" "current" {}
 
 # Fixing "Error: creating KMS Key: operation error KMS: CreateKey, https response error StatusCode: 400, RequestID: 0690d6a8-4211-4a06-a2ad-febc524ae3f1, MalformedPolicyDocumentException: Policy contains a statement with one or more invalid principals."

--- a/cluster/terraform.tfvars
+++ b/cluster/terraform.tfvars
@@ -4,8 +4,6 @@ bucket = "project1-dev-tf-state-us-east-2"
 cluster_name = "project1-dev"
 org_name     = "devopscoop"
 region       = "us-east-2"
-# Region that the Loki S3 buckets replicate to for cross-region redundancy.
-replica_region = "us-west-2"
 
 cluster_version = "1.35"
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -55,10 +55,6 @@ variable "create_route53_zone" {
 variable "region" {
   type = string
 }
-variable "replica_region" {
-  type        = string
-  description = "AWS region the Loki S3 buckets replicate to for cross-region redundancy. Must differ from region."
-}
 variable "tags_git_repo" {
   type        = string
   description = "All AWS resources will have a tag named GitRepo with this value, so we know which repo created our resources."


### PR DESCRIPTION
## Summary

Removes cross-region replication for the Loki S3 buckets and marks all log-storage buckets `VantaNoAlert` so they aren't flagged for lacking a DR copy.

**Why:** Loki holds operational log data, not the long-term audit record. The compliance-relevant logs — VPC flow logs and EKS control-plane logs (both retained 365 days for the SOC 2 observation window) — are *not* replicated. Replicating only Loki was inconsistent, and cost storage + cross-region transfer for little DR value: if the region is lost the cluster is gone too, and historical app logs aren't on the critical restore path.

## Changes

- **Remove Loki cross-region replication** (`loki.tf`): the replica buckets, replication IAM role/policy, and `aws_s3_bucket_replication_configuration`.
- **Drop source-bucket versioning** — it existed solely as a replication prerequisite (per its own comment) and adds only overhead on write-once log data. Removed the `noncurrent_version_expiration` rule and the unused `loki_noncurrent_version_expiration_days` local; kept the incomplete-multipart-upload cleanup.
- **Remove the now-orphaned `aws.replica` provider** (`main.tf`) and `replica_region` variable (`variables.tf` / `terraform.tfvars`).
- **Tag `VantaNoAlert`** on the Loki source buckets and the VPC flow-logs bucket, with the reason recorded in the tag value.

## Validation

- `tofu validate` → valid
- `tofu fmt -check` → clean
- Grep confirms no dangling references to removed resources/vars/provider.

## ⚠️ Apply-time notes (for whoever runs `apply` on existing clusters)

- **Replica buckets won't `destroy` while non-empty** — they hold versioned objects, so empty them first (or temporarily set `force_destroy`). Intentionally *not* added here, so log data isn't deleted silently.
- **Existing noncurrent versions on the source buckets won't be auto-purged** — removing the versioning resource suspends versioning but leaves old versions; clean up manually if it matters.

## Note on scope

`VantaNoAlert` takes a bucket out of scope for **all** Vanta tests, not just the replication one. Encryption, public-access block, and HTTPS-only are still enforced in Terraform here, so posture is unchanged — but Vanta will no longer independently verify them for these buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)