### PR TITLE
Enable DNS query logging on the public Route 53 hosted zone

### DIFF
--- a/cluster/route53.tf
+++ b/cluster/route53.tf
@@ -12,4 +12,92 @@ locals {
   hosted_zone_arn = var.enable_route53 ? (
     var.create_route53_zone ? aws_route53_zone.primary[0].arn : data.aws_route53_zone.primary[0].arn
   ) : null
+  hosted_zone_id = var.enable_route53 ? (
+    var.create_route53_zone ? aws_route53_zone.primary[0].zone_id : data.aws_route53_zone.primary[0].zone_id
+  ) : null
+}
+
+################################################################################
+# DNS query logging
+#
+# Route 53 delivers public-zone query logs only to CloudWatch Logs log groups
+# in us-east-1 (Route 53 is a global service homed there), so the log group and
+# the CloudWatch Logs resource policy that lets Route 53 write to it use an
+# aliased us-east-1 provider regardless of var.region. Query logging supports
+# SOC 2 (CC7.2, System Monitoring) and ISO/IEC 27001:2022 Annex A 8.15
+# (Logging); 365 days of retention matches the EKS control-plane log retention
+# (main.tf) and covers the 12-month SOC 2 Type II observation period.
+#
+# Route 53 allows a single query logging config per hosted zone. If
+# create_route53_zone = false and the pre-existing zone already has query
+# logging enabled, import that config into aws_route53_query_log.primary
+# instead of letting this create a conflicting one.
+################################################################################
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = local.tags
+  }
+}
+
+resource "aws_cloudwatch_log_group" "route53_query_logs" {
+  count    = var.enable_route53 ? 1 : 0
+  provider = aws.us_east_1
+
+  name              = "/aws/route53/${var.zone_name}"
+  retention_in_days = 365
+}
+
+# CloudWatch Logs resource policy granting the Route 53 service permission to
+# deliver query logs into /aws/route53/* log groups. The SourceAccount/
+# SourceArn conditions scope delivery to this account's hosted zones and guard
+# against the confused-deputy problem (same pattern as flow-logs.tf).
+data "aws_iam_policy_document" "route53_query_logging" {
+  count = var.enable_route53 ? 1 : 0
+
+  statement {
+    sid       = "Route53QueryLoggingWrite"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/route53/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["route53.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:route53:::hostedzone/*"]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "route53_query_logging" {
+  count    = var.enable_route53 ? 1 : 0
+  provider = aws.us_east_1
+
+  policy_name     = "${var.cluster_name}-route53-query-logging"
+  policy_document = data.aws_iam_policy_document.route53_query_logging[0].json
+}
+
+resource "aws_route53_query_log" "primary" {
+  count = var.enable_route53 ? 1 : 0
+
+  zone_id                  = local.hosted_zone_id
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.route53_query_logs[0].arn
+
+  # Route 53 checks the resource policy when the query logging config is
+  # created, so it must exist first.
+  depends_on = [aws_cloudwatch_log_resource_policy.route53_query_logging]
 }


### PR DESCRIPTION
## Summary

Ensures the public Route 53 hosted zone has query logging enabled with a CloudWatch Logs log group, in both template modes (`create_route53_zone` true or false). All changes are in `cluster/route53.tf`, gated on `var.enable_route53`:

- `aws_route53_query_log.primary` associates the zone (created or pre-existing, via a new `local.hosted_zone_id`) with the log group.
- `aws_cloudwatch_log_group.route53_query_logs` (`/aws/route53/${var.zone_name}`) with 365-day retention, matching the EKS control-plane and VPC flow log retention rationale (SOC 2 Type II observation period).
- `aws_cloudwatch_log_resource_policy.route53_query_logging` authorizes `route53.amazonaws.com` to write to `/aws/route53/*`, with `aws:SourceAccount`/`aws:SourceArn` confused-deputy conditions following the `flow-logs.tf` pattern.
- A new `aws.us_east_1` provider alias (with the same `default_tags`): Route 53 only accepts us-east-1 log group ARNs for public-zone query logging, and the CloudWatch Logs resource policy is per-region, so both must live there regardless of `var.region`.

## Caveat

Route 53 allows one query logging config per zone. If a pre-existing zone (`create_route53_zone = false`) already has query logging enabled, import it into `aws_route53_query_log.primary` rather than letting apply fail with a conflict (noted in the file comments).

## Testing

- `tofu init -backend=false && tofu validate` passes; `tofu fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)