### PR TITLE
Add free S3 gateway endpoint to the cluster VPC

### DIFF
--- a/cluster/s3-gateway-endpoint.tf
+++ b/cluster/s3-gateway-endpoint.tf
@@ -1,0 +1,37 @@
+################################################################################
+# S3 Gateway VPC Endpoint
+#
+# ECR image layers are stored in and served from S3
+# (https://docs.aws.amazon.com/AmazonECR/latest/userguide/vpc-endpoints.html),
+# so without this endpoint every image pull by a node leaves the VPC through
+# the NAT gateway and pays its per-GB data-processing fee. In one fork of this
+# template, image-layer pulls were ~13% of a month's NAT gateway data
+# processing. Gateway endpoints cost nothing — no hourly rate and no per-GB
+# charge (https://aws.amazon.com/privatelink/pricing/) — and route same-region
+# S3 traffic through an S3 prefix-list entry in the attached route tables
+# instead, so this is pure savings for every cluster built from the template.
+#
+# Limits worth knowing:
+#   - Same-region S3 only; cross-region and on-prem (DX/VPN) paths are
+#     unaffected.
+#   - This cluster is IPv6 (ip_family in main.tf), and IPv6-only pods reach
+#     S3 via DNS64/NAT64, which still traverses — and pays for — the NAT
+#     gateway. The endpoint fixes node-level traffic (image pulls happen over
+#     the node's IPv4 stack); pod S3 traffic avoids NAT only when workloads
+#     opt into S3 dual-stack endpoints (AWS_USE_DUALSTACK_ENDPOINT=true).
+#
+# The public route tables are attached too, so S3-bound traffic exiting the
+# NAT gateway itself (e.g. that NAT64 pod path) reaches S3 through the
+# endpoint rather than the internet gateway.
+################################################################################
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = concat(module.vpc.private_route_table_ids, module.vpc.public_route_table_ids)
+
+  tags = merge(local.tags, {
+    Name = "${local.name}-s3-gateway"
+  })
+}


### PR DESCRIPTION
## What

Adds an S3 gateway VPC endpoint attached to all private and public route tables, as a standalone `cluster/s3-gateway-endpoint.tf` (same extension pattern as `flow-logs.tf`/`loki.tf`, so `main.tf`'s diff-against-blueprint-upstream headers stay clean).

## Why

ECR image layers are stored in and served from S3, so on the template's topology (nodes in private subnets, `single_nat_gateway = true`) every node image pull exits through the NAT gateway and pays its per-GB data-processing fee. Gateway endpoints have **no hourly and no per-GB charge** — this is pure savings for every fork. In one production fork, image-layer pulls measured via VPC flow logs were **~13% of a month's NAT gateway data processing**.

Scope, documented in the file comment: same-region S3 only, and because the cluster is IPv6 (`ip_family`), this fixes *node-level* (IPv4) traffic — IPv6-only pods reaching S3 via DNS64/NAT64 still pay the NAT fee unless workloads opt into S3 dual-stack endpoints. The public route tables are attached so even that NAT64 path exits via the endpoint rather than the IGW.

## Verification

`tofu fmt -check` and `tofu validate` pass. The template repo has no live cluster, so a plan cannot exercise this here — but the identical change was planned against a real fork's cluster state (furlai/dev-infra#248): exactly `1 to add, 0 to change, 0 to destroy` (`aws_vpc_endpoint.s3`), and gateway endpoints are additive routing with no security-group or NACL interaction, so apply risk is minimal. Rollback is deleting the endpoint.

Forks that already added this file locally will hit a one-time subtree-sync conflict on the path; taking the template version is safe (same resource address, no state surgery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)