### PR TITLE
Add Karpenter controller IRSA role, node role, and interruption queue

### DIFF
--- a/cluster/karpenter.tf
+++ b/cluster/karpenter.tf
@@ -1,0 +1,111 @@
+# AWS-side resources for Karpenter, the node autoscaler. The controller itself
+# is a Helm release reconciled by Flux from fluxcd-template (apps/karpenter);
+# per this repo's pattern, only the IAM/IRSA pieces live here and the role ARN
+# gets pasted into the ServiceAccount annotation over there.
+#
+# The other IRSA roles in this repo use
+# terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts, but
+# that module dropped its Karpenter policy in v6 in favor of this sub-module
+# of the EKS module (pinned to the same version as module.eks). The sub-module
+# also creates everything else Karpenter needs on the AWS side:
+#
+#   - the controller IAM role and its (versioned, Karpenter-1.x) policy
+#   - the node IAM role that Karpenter-launched instances run as
+#   - the EKS access entry that lets those nodes join the cluster
+#   - the SQS queue + EventBridge rules for spot interruption / rebalance /
+#     scheduled-maintenance handling
+#
+# https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/21.24.2/submodules/karpenter
+
+# From v21 the sub-module only writes an EKS Pod Identity trust policy
+# (pods.eks.amazonaws.com) for the controller role; the IRSA variables were
+# removed. This cluster uses IRSA for every controller (see AGENTS.md), and
+# the fluxcd-template side already ships the eks.amazonaws.com/role-arn
+# annotation, so we override the trust policy with the classic OIDC-federated
+# one.
+data "aws_iam_policy_document" "karpenter_controller_assume_role" {
+  # The sid must remain "PodIdentity": documents passed through
+  # iam_role_override_assume_policy_documents override base statements by
+  # matching sid, and "PodIdentity" is the sid of the sub-module's built-in
+  # pod-identity statement. Any other sid would append this statement instead
+  # of replacing that one.
+  statement {
+    sid     = "PodIdentity"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    # Bind the role to exactly the karpenter ServiceAccount in the karpenter
+    # namespace (fluxcd-template deploys the chart there, and the chart's
+    # ServiceAccount name defaults to the release name).
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:sub"
+      values   = ["system:serviceaccount:karpenter:karpenter"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+module "karpenter" {
+  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version = "21.24.2"
+
+  cluster_name = module.eks.cluster_name
+
+  # The role name is what the eks.amazonaws.com/role-arn annotation in
+  # fluxcd-template (apps/karpenter/values.yaml) points at; keep them in sync.
+  # The module default is "KarpenterController" with a name prefix.
+  iam_role_name            = "karpenter"
+  iam_role_use_name_prefix = false
+
+  iam_role_override_assume_policy_documents = [
+    data.aws_iam_policy_document.karpenter_controller_assume_role.json
+  ]
+
+  # IRSA, not Pod Identity — see the comment on the trust policy above. (The
+  # association would also default to the kube-system namespace, not
+  # karpenter.)
+  create_pod_identity_association = false
+
+  # The node role's CNI policy must match the cluster's IP family: main.tf
+  # sets ip_family = "ipv6", and its create_cni_ipv6_iam_policy = true creates
+  # the account-level AmazonEKS_CNI_IPv6_Policy that this setting attaches.
+  cluster_ip_family = "ipv6"
+
+  # Predictable, cluster-agnostic name for EC2NodeClass spec.role references
+  # in fluxcd-template, consistent with the static names used by the other
+  # roles in this repo. The module default is "Karpenter-<cluster_name>".
+  node_iam_role_name            = "karpenter-node"
+  node_iam_role_use_name_prefix = false
+
+  # Name the interruption queue after the cluster, like the karpenter.sh
+  # getting-started guide does. The module default is "Karpenter-<cluster>";
+  # the bare cluster name is what apps/karpenter/values.yaml documents for
+  # settings.interruptionQueue, and both repos' placeholder replacement
+  # rewrites it on fork.
+  queue_name = module.eks.cluster_name
+}
+
+output "karpenter_role_arn" {
+  description = "IRSA role ARN for the Karpenter controller ServiceAccount. Set this as the eks.amazonaws.com/role-arn annotation in fluxcd-template (apps/karpenter/values.yaml, eks marker block)."
+  value       = module.karpenter.iam_role_arn
+}
+
+output "karpenter_node_iam_role_name" {
+  description = "IAM role name for Karpenter-launched nodes. Set this as spec.role in EC2NodeClass resources in fluxcd-template (apps/karpenter-custom-resources)."
+  value       = module.karpenter.node_iam_role_name
+}
+
+output "karpenter_interruption_queue_name" {
+  description = "SQS queue name for interruption handling. Set this as settings.interruptionQueue in fluxcd-template (apps/karpenter/values.yaml)."
+  value       = module.karpenter.queue_name
+}

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -130,6 +130,15 @@ module "eks" {
   # which will allow resources to be deployed into the cluster
   enable_cluster_creator_admin_permissions = true
 
+  # Karpenter's EC2NodeClass discovers which security group to attach to the
+  # nodes it launches by this tag (spec.securityGroupSelectorTerms in
+  # fluxcd-template's apps/karpenter-custom-resources). Tag only the node
+  # security group — tagging more than one SG with the same discovery key
+  # makes Karpenter attach all of them.
+  node_security_group_tags = {
+    "karpenter.sh/discovery" = local.name
+  }
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
@@ -233,6 +242,11 @@ module "vpc" {
 
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
+    # Karpenter's EC2NodeClass discovers which subnets to launch nodes into by
+    # this tag (spec.subnetSelectorTerms in fluxcd-template's
+    # apps/karpenter-custom-resources). Private subnets only — nodes never
+    # belong in the public ones.
+    "karpenter.sh/discovery" = local.name
   }
 }
 


### PR DESCRIPTION
## Summary

Companion to devopscoop/fluxcd-template#37 (the Karpenter Helm release). This adds the AWS-side resources Karpenter needs:

- `cluster/karpenter.tf` — the Karpenter controller IRSA role (`role/karpenter`, matching the `eks.amazonaws.com/role-arn` annotation in fluxcd-template), the `karpenter-node` IAM role, the EKS access entry that lets Karpenter-launched nodes join the cluster, and the SQS interruption queue + EventBridge rules.
- Discovery tags in `cluster/main.tf`: `karpenter.sh/discovery = <cluster_name>` on the private subnets and the node security group, for the EC2NodeClass selector terms in the upcoming `karpenter-custom-resources` app.
- Three outputs (`karpenter_role_arn`, `karpenter_node_iam_role_name`, `karpenter_interruption_queue_name`), each description naming the fluxcd-template file it gets pasted into.

## Why the eks//karpenter sub-module instead of the usual IRSA shape

The other controllers use `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts`, but v6 of that module dropped its Karpenter policy in favor of the EKS module's `karpenter` sub-module, which also maintains the Karpenter-1.x controller policy and the node-role/access-entry/queue plumbing. It's pinned to `module.eks`'s version (21.24.2).

Two things the comments explain in detail:

- v21 of the sub-module only writes an EKS Pod Identity trust policy, so the trust is overridden back to IRSA via `iam_role_override_assume_policy_documents`; the override statement reuses the sid `PodIdentity` because that's how the built-in statement gets replaced rather than appended.
- `cluster_ip_family = "ipv6"` so the node role gets the `AmazonEKS_CNI_IPv6_Policy` that `main.tf` already creates.

## Validation

`tofu fmt -check` and `tofu validate` pass locally. Per AGENTS.md, only `tofu plan` catches real errors — that runs in CI on this PR, so please review the posted plan before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
