### PR TITLE
karpenter: create the EC2 spot service-linked role

### DIFF
--- a/cluster/karpenter.tf
+++ b/cluster/karpenter.tf
@@ -101,13 +101,21 @@ module "karpenter" {
 # apps/karpenter-custom-resources). The getting-started guide creates it
 # imperatively (aws iam create-service-linked-role --aws-service-name
 # spot.amazonaws.com); manage it here instead so forks get it without a manual
-# step. There is exactly one per account: if the account has ever used spot
-# the role already exists and creating it fails with InvalidInput — import it
-# instead:
-#   tofu import aws_iam_service_linked_role.spot \
-#     arn:aws:iam::<account-id>:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot
+# step.
+#
+# The gate exists because there is exactly one such role per account, and any
+# prior spot use — an ASG, the console, another cluster — creates it
+# implicitly. A plan can't see that (name collisions only surface at create),
+# so an unconditional resource would plan green and then fail the apply on
+# main with InvalidInput; since cluster/ is applied by CI only, the tofu
+# import that recovers from this isn't reachable without breaking that rule.
+# Forks in an account that already has the role set
+# create_spot_service_linked_role = false in terraform.tfvars and skip both
+# the create and — equally important in a shared account — the destroy.
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/service-linked-roles-spot-instance-requests.html
 resource "aws_iam_service_linked_role" "spot" {
+  count = var.create_spot_service_linked_role ? 1 : 0
+
   aws_service_name = "spot.amazonaws.com"
 }
 

--- a/cluster/karpenter.tf
+++ b/cluster/karpenter.tf
@@ -95,6 +95,22 @@ module "karpenter" {
   queue_name = module.eks.cluster_name
 }
 
+# EC2 refuses spot requests until the account-level AWSServiceRoleForEC2Spot
+# service-linked role exists, so this is a prerequisite for "spot" in a
+# NodePool's karpenter.sh/capacity-type requirements (fluxcd-template,
+# apps/karpenter-custom-resources). The getting-started guide creates it
+# imperatively (aws iam create-service-linked-role --aws-service-name
+# spot.amazonaws.com); manage it here instead so forks get it without a manual
+# step. There is exactly one per account: if the account has ever used spot
+# the role already exists and creating it fails with InvalidInput — import it
+# instead:
+#   tofu import aws_iam_service_linked_role.spot \
+#     arn:aws:iam::<account-id>:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/service-linked-roles-spot-instance-requests.html
+resource "aws_iam_service_linked_role" "spot" {
+  aws_service_name = "spot.amazonaws.com"
+}
+
 output "karpenter_role_arn" {
   description = "IRSA role ARN for the Karpenter controller ServiceAccount. Set this as the eks.amazonaws.com/role-arn annotation in fluxcd-template (apps/karpenter/values.yaml, eks marker block)."
   value       = module.karpenter.iam_role_arn

--- a/cluster/terraform.tfvars
+++ b/cluster/terraform.tfvars
@@ -20,6 +20,9 @@ eks_addon_version_vpc-cni                   = "v1.23.0-eksbuild.1"
 enable_image_reflector_controller = true
 enable_route53                    = true
 create_route53_zone               = true
+# Set false if the account already has AWSServiceRoleForEC2Spot (any prior
+# spot use creates it implicitly); see cluster/karpenter.tf.
+create_spot_service_linked_role = true
 
 # Email addresses that receive CloudWatch alarm notifications, e.g. high CPU
 # on an EKS node (see cloudwatch-alarms.tf). Each address must confirm the

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -55,6 +55,10 @@ variable "create_route53_zone" {
   type    = bool
   default = true
 }
+variable "create_spot_service_linked_role" {
+  type        = bool
+  description = "Creates the account-level AWSServiceRoleForEC2Spot service-linked role that spot NodePools depend on. Set false if the account already has it (any prior spot use creates it implicitly) or another stack manages it — see cluster/karpenter.tf."
+}
 variable "region" {
   type = string
 }


### PR DESCRIPTION
EC2 refuses spot requests until the account-level `AWSServiceRoleForEC2Spot` service-linked role exists, so it is a prerequisite for allowing `spot` in NodePool `capacity-type` requirements — companion PR: devopscoop/fluxcd-template#39. The getting-started guide creates the role imperatively with the AWS CLI; managing it in `cluster/karpenter.tf` means forks in a fresh account get it without a manual step.

The resource is gated behind `create_spot_service_linked_role` (declared in `variables.tf`, value in `terraform.tfvars`, following the `enable_image_reflector_controller` convention). There is exactly one such role per account and any prior spot use — an ASG, the console, another cluster — creates it implicitly; a plan can't see the name collision, so an unconditional resource would plan green and fail the apply on main, with the `tofu import` recovery unreachable under the "cluster/ is applied by CI only" rule. Forks in such an account set the gate to `false` and skip both the create and (relevant for shared accounts) the destroy.

**Note for downstream merges (dev-infra / prod-infra):** the subtree copies replaced `terraform.tfvars` with `*.auto.tfvars`, so the merge must add `create_spot_service_linked_role = true` there (e.g. `aws-eks/cluster/dev.auto.tfvars`) or the CI plan fails on a missing required variable. Verified neither the furl dev nor prod account currently has the role, so `true` is correct for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)