### PR TITLE
Rename Karpenter interruption queue and alarm on ApproximateAgeOfOldestMessage

### DIFF
--- a/cluster/cloudwatch-alarms.tf
+++ b/cluster/cloudwatch-alarms.tf
@@ -53,6 +53,58 @@ resource "aws_cloudwatch_metric_alarm" "node_cpu" {
 }
 
 ################################################################################
+# SQS queue age CloudWatch alarms
+#
+# Vanta's "SQS queues monitored and alarmed" test requires every SQS queue to
+# be covered by a CloudWatch alarm on the ApproximateAgeOfOldestMessage
+# metric, which indicates message processing delays or queue blockage. Queue
+# monitoring supports SOC 2 CC7.2 (System Monitoring) and ISO/IEC 27001:2022
+# Annex A 8.16 (Monitoring activities).
+#
+# The only queue in this root module is Karpenter's interruption queue
+# (karpenter.tf). A healthy Karpenter controller drains it within seconds, so
+# a message sitting for minutes means interruption handling is down and spot
+# reclaims / scheduled maintenance will hit nodes without graceful draining.
+################################################################################
+
+locals {
+  # Alert when the oldest message has been in the queue at least this long for
+  # queue_age_alarm_minutes. The Karpenter sub-module hardcodes the queue's
+  # message_retention_seconds to 300, so this metric can never exceed 300 —
+  # SQS silently drops older messages. The threshold must therefore stay well
+  # below 300 or the alarm could never fire.
+  queue_age_alarm_threshold_seconds = 120
+  queue_age_alarm_minutes           = 10
+}
+
+resource "aws_cloudwatch_metric_alarm" "karpenter_interruption_queue_age" {
+  alarm_name        = "${local.name}-karpenter-interruption-queue-age"
+  alarm_description = "ApproximateAgeOfOldestMessage of SQS queue ${local.name}-karpenter-interruption has been >= ${local.queue_age_alarm_threshold_seconds}s for ${local.queue_age_alarm_minutes} minutes. Karpenter is not consuming interruption events, so spot interruptions and scheduled maintenance will terminate nodes without graceful draining."
+
+  namespace   = "AWS/SQS"
+  metric_name = "ApproximateAgeOfOldestMessage"
+  statistic   = "Maximum"
+
+  dimensions = {
+    QueueName = module.karpenter.queue_name
+  }
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = local.queue_age_alarm_threshold_seconds
+  period              = 300
+  evaluation_periods  = local.queue_age_alarm_minutes * 60 / 300
+
+  # SQS only emits metrics for queues that have been active in the last ~6
+  # hours; an idle interruption queue reports nothing at all. Without this the
+  # alarm would sit in INSUFFICIENT_DATA through every quiet stretch — no
+  # data means no stuck messages, so treat it as OK.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+################################################################################
 # Alarm notification delivery
 #
 # An alarm with no action satisfies the Vanta test but alerts no one, so alarm

--- a/cluster/karpenter.tf
+++ b/cluster/karpenter.tf
@@ -87,12 +87,15 @@ module "karpenter" {
   node_iam_role_name            = "karpenter-node"
   node_iam_role_use_name_prefix = false
 
-  # Name the interruption queue after the cluster, like the karpenter.sh
-  # getting-started guide does. The module default is "Karpenter-<cluster>";
-  # the bare cluster name is what apps/karpenter/values.yaml documents for
-  # settings.interruptionQueue, and both repos' placeholder replacement
-  # rewrites it on fork.
-  queue_name = module.eks.cluster_name
+  # "<cluster>-karpenter-interruption" so the queue is recognizable in the
+  # console as Karpenter's interruption queue rather than an anonymous
+  # cluster-named queue (the module default is "Karpenter-<cluster>", which
+  # buries what the queue is *for*). This name is what
+  # apps/karpenter/values.yaml sets for settings.interruptionQueue — keep them
+  # in sync; the cluster-name prefix is rewritten by both repos' placeholder
+  # replacement on fork. The queue age alarm in cloudwatch-alarms.tf
+  # references it through module.karpenter.queue_name, so it follows along.
+  queue_name = "${module.eks.cluster_name}-karpenter-interruption"
 }
 
 # EC2 refuses spot requests until the account-level AWSServiceRoleForEC2Spot


### PR DESCRIPTION
## What

- **Rename the Karpenter interruption queue** from the bare cluster name to `<cluster>-karpenter-interruption`, so it's recognizable in the console as Karpenter's interruption queue instead of an anonymous queue named e.g. `prod`. The coupled `settings.interruptionQueue` change is devopscoop/fluxcd-template PR (linked below) — both must roll out together in a fork.
- **Add a CloudWatch alarm** on the queue's `ApproximateAgeOfOldestMessage` (Maximum >= 120s for 10 minutes), wired to the existing alarms SNS topic, following the node-CPU alarm pattern. This satisfies Vanta's "SQS queues monitored and alarmed" test (SOC 2 CC7.2, ISO/IEC 27001:2022 A 8.16).

## Details

- The karpenter sub-module hardcodes the queue's `message_retention_seconds` at 300, so the age metric physically caps at 300 — a threshold above that would never fire. 120s is well under the cap and far above the seconds-level drain latency of a healthy controller.
- `treat_missing_data = "notBreaching"`: SQS stops emitting metrics for queues idle for ~6 hours, so without it the alarm would sit in INSUFFICIENT_DATA during quiet stretches.

## Rollout note for forks

SQS queue names are immutable, so applying this destroys the old queue and creates the new one. Between the tofu apply and Flux rolling the updated Karpenter values, the controller polls a queue that no longer exists and interruption events are dropped — land both changes in each environment close together.

## Verification

`tofu fmt -check` and `tofu validate` pass. Per AGENTS.md, plan is the real check and only runs in fork CI (the job is skipped on this template repo), so the first fork sync will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)