### PR TITLE
Alarm on NLB target-group health, discovered via LBC tags

### DIFF
--- a/cluster/cloudwatch-alarms.tf
+++ b/cluster/cloudwatch-alarms.tf
@@ -105,6 +105,156 @@ resource "aws_cloudwatch_metric_alarm" "karpenter_interruption_queue_age" {
 }
 
 ################################################################################
+# NLB target-group health CloudWatch alarms
+#
+# The AWS Load Balancer Controller creates an NLB (plus one target group per
+# listener port) for every LoadBalancer Service in the cluster — the Envoy
+# Gateway gateways from the companion fluxcd-template repo, which are the
+# cluster's only traffic entry points. When a target group has no healthy
+# targets, the cluster is down from the internet's perspective no matter what
+# the pods think, so that's the signal to alarm on. Load balancer monitoring
+# supports SOC 2 CC7.2 (System Monitoring) and ISO/IEC 27001:2022 Annex A 8.16
+# (Monitoring activities).
+#
+# The controller mints the LB and target-group names (k8s-envoygat-…/<hash>),
+# and re-mints them whenever a Service is recreated or its traffic config
+# materially changes, so per-target-group alarms can't be declared statically
+# the way the node CPU alarms can. Hand-pinning the generated ARN suffixes has
+# been tried in a fork and rotted within days of an LB replacement. Instead,
+# discover the dimensions through the controller's own tags: every LB and
+# target group it manages carries elbv2.k8s.aws/cluster = <cluster name> and
+# service.k8s.aws/stack = <namespace>/<service>, and each target group names
+# its listener in service.k8s.aws/resource = <namespace>/<service>:<port>.
+# https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/configurations/#aws-resource-tags
+#
+# The discovery trade-off: data sources read at plan time, so alarm coverage
+# is only as fresh as the last pipeline run. Two consequences to know about:
+#
+#  - On a cluster where Flux hasn't created the gateway Services yet (first
+#    bootstrap), the lookups match nothing and no alarms exist. They appear on
+#    the first apply after the NLBs do — merge any PR, or re-run the apply
+#    workflow, once the gateways are up.
+#  - If a Service is recreated, the alarms keep the dead dimensions until the
+#    next apply. treat_missing_data = "breaching" below makes that state page
+#    loudly instead of sitting quietly in INSUFFICIENT_DATA while monitoring
+#    nothing — the fix is simply to re-run the pipeline, which re-reads the
+#    tags and updates the dimensions in place.
+################################################################################
+
+locals {
+  # Alert when a target group has had an unhealthy target (or no healthy
+  # target) for this many consecutive minutes.
+  nlb_health_alarm_minutes = 3
+}
+
+data "aws_resourcegroupstaggingapi_resources" "lbc_load_balancers" {
+  resource_type_filters = ["elasticloadbalancing:loadbalancer"]
+
+  tag_filter {
+    key    = "elbv2.k8s.aws/cluster"
+    values = [local.name]
+  }
+
+  # Key-only filter: any value. Restricts the match to Service-created NLBs;
+  # the controller tags Ingress-created ALBs with ingress.k8s.aws/* instead,
+  # and those have different metrics and failure modes.
+  tag_filter {
+    key = "service.k8s.aws/stack"
+  }
+}
+
+data "aws_resourcegroupstaggingapi_resources" "lbc_target_groups" {
+  resource_type_filters = ["elasticloadbalancing:targetgroup"]
+
+  tag_filter {
+    key    = "elbv2.k8s.aws/cluster"
+    values = [local.name]
+  }
+
+  tag_filter {
+    key = "service.k8s.aws/stack"
+  }
+}
+
+locals {
+  # <namespace>/<service> => the "net/<name>/<id>" CloudWatch LoadBalancer
+  # dimension, cut from the LB ARN (…:loadbalancer/net/<name>/<id>). The
+  # controller creates exactly one LB per Service stack.
+  lbc_lb_dimension_by_stack = {
+    for r in data.aws_resourcegroupstaggingapi_resources.lbc_load_balancers.resource_tag_mapping_list :
+    r.tags["service.k8s.aws/stack"] => regex("loadbalancer/(.+)$", r.resource_arn)[0]
+  }
+
+  # <namespace>-<service>-<port> (the service.k8s.aws/resource tag, sanitized
+  # for use in alarm names) => that target group's CloudWatch dimension pair.
+  # Target groups whose stack no longer has an LB are skipped: the controller
+  # can leave orphaned target groups behind, and an alarm on one could never
+  # receive data again.
+  lbc_target_group_dimensions = {
+    for r in data.aws_resourcegroupstaggingapi_resources.lbc_target_groups.resource_tag_mapping_list :
+    replace(join("-", split("/", r.tags["service.k8s.aws/resource"])), ":", "-") => {
+      service       = r.tags["service.k8s.aws/resource"]
+      load_balancer = local.lbc_lb_dimension_by_stack[r.tags["service.k8s.aws/stack"]]
+      target_group  = regex("(targetgroup/.+)$", r.resource_arn)[0]
+    } if contains(keys(local.lbc_lb_dimension_by_stack), r.tags["service.k8s.aws/stack"])
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
+  for_each = local.lbc_target_group_dimensions
+
+  alarm_name        = "${local.name}-nlb-${each.key}-unhealthy-hosts"
+  alarm_description = "The NLB target group for ${each.value.service} on cluster ${local.name} has had an unhealthy target for ${local.nlb_health_alarm_minutes} minutes. Missing data also alarms: if the Service was recreated, the controller minted new LB/target-group names — re-run the apply pipeline to re-discover them."
+
+  namespace   = "AWS/NetworkELB"
+  metric_name = "UnHealthyHostCount"
+  statistic   = "Maximum"
+
+  dimensions = {
+    LoadBalancer = each.value.load_balancer
+    TargetGroup  = each.value.target_group
+  }
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 60
+  evaluation_periods  = local.nlb_health_alarm_minutes
+  datapoints_to_alarm = local.nlb_health_alarm_minutes
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# UnHealthyHostCount alone misses the zero-registered-targets case (0 targets
+# => 0 unhealthy), so also require at least one healthy target.
+resource "aws_cloudwatch_metric_alarm" "nlb_no_healthy_hosts" {
+  for_each = local.lbc_target_group_dimensions
+
+  alarm_name        = "${local.name}-nlb-${each.key}-no-healthy-hosts"
+  alarm_description = "The NLB target group for ${each.value.service} on cluster ${local.name} has had no healthy targets for ${local.nlb_health_alarm_minutes} minutes — the gateway is down from AWS's perspective. Missing data also alarms: if the Service was recreated, the controller minted new LB/target-group names — re-run the apply pipeline to re-discover them."
+
+  namespace   = "AWS/NetworkELB"
+  metric_name = "HealthyHostCount"
+  statistic   = "Minimum"
+
+  dimensions = {
+    LoadBalancer = each.value.load_balancer
+    TargetGroup  = each.value.target_group
+  }
+
+  comparison_operator = "LessThanThreshold"
+  threshold           = 1
+  period              = 60
+  evaluation_periods  = local.nlb_health_alarm_minutes
+  datapoints_to_alarm = local.nlb_health_alarm_minutes
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+################################################################################
 # Alarm notification delivery
 #
 # An alarm with no action satisfies the Vanta test but alerts no one, so alarm


### PR DESCRIPTION
## Why

The AWS Load Balancer Controller creates an NLB (plus one target group per listener port) for every Envoy Gateway LoadBalancer Service from fluxcd-template — these are the cluster's only traffic entry points, and none of them were monitored by this stack.

A fork (furlai/dev-infra) had alarms on hand-pinned, controller-generated ARN suffixes, with `treat_missing_data = "breaching"` so stale pins fail loud. That design worked as intended but rotted fast: the `eg-public` NLB was replaced on 2026-08-20 (new `net/…` name, same target groups), the metric stream under the pinned dimension pair went dead, and four alarms sat in permanent ALARM for two days until a human re-ran a shell snippet and edited the file. That file carried a `TODO: move this to the upstream aws-eks-template repo` — this PR is that move, minus the rot.

## What

Two `aws_resourcegroupstaggingapi_resources` data sources discover every Service-created NLB and target group through the controller's own tags (`elbv2.k8s.aws/cluster` = cluster name, `service.k8s.aws/stack` = namespace/service), and each target group gets two alarms:

- `UnHealthyHostCount >= 1` for 3 minutes (Maximum)
- `HealthyHostCount < 1` for 3 minutes (Minimum) — catches the zero-registered-targets case, where 0 targets means 0 *unhealthy* targets

`treat_missing_data = "breaching"` is kept: NLB target groups emit health metrics continuously while they exist, so missing data genuinely means the dimensions are stale or the LB is gone. The difference from pinning is the remedy — re-running the apply pipeline re-reads the tags and updates the dimensions in place, no file edit.

Ingress-created ALBs are deliberately out of scope (`ingress.k8s.aws/*` tags, different metrics namespace); orphaned target groups whose LB is gone are skipped.

## Trade-offs

- Discovery happens at plan time, so coverage is only as fresh as the last pipeline run. On first bootstrap (before Flux creates the gateways) no alarms exist until an apply runs after the NLBs exist; after a Service recreation the alarms page until the next apply. Both are documented in the file header.
- The CI role needs `tag:GetResources`; the `configure-aws-credentials` CloudFormation role is currently `Action: '*'`, so nothing to change today, but worth remembering when that TODO gets tightened.

## Verification

`tofu fmt -check` and `tofu validate` pass. `plan` can't exercise this from the template repo, so the data sources + locals were extracted into a scratch root module and planned against a live cluster account: they returned all six gateway target groups (agent/private/public × 80/443) with correct dimension pairs — including the replaced `eg-public` LB (`net/k8s-envoygat-envoyenv-2bfda71368/…`) that the pinned values had missed. The alarm resources themselves only get exercised by a fork's apply.

## Follow-up for forks

After this lands and forks pull the subtree: furlai/dev-infra should delete its root-module `nlb-alarms.tf` (the ENG-1073 pinned version) so the old alarms are destroyed and replaced by these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)