### PR TITLE
Let alarms publish to an existing SNS topic via alarm_topic_arn

### DIFF
--- a/cluster/cloudwatch-alarms.tf
+++ b/cluster/cloudwatch-alarms.tf
@@ -48,8 +48,8 @@ resource "aws_cloudwatch_metric_alarm" "node_cpu" {
   period              = 300
   evaluation_periods  = local.node_cpu_alarm_minutes * 60 / 300
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
 }
 
 ################################################################################
@@ -100,26 +100,50 @@ resource "aws_cloudwatch_metric_alarm" "karpenter_interruption_queue_age" {
   # data means no stuck messages, so treat it as OK.
   treat_missing_data = "notBreaching"
 
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
 }
 
 ################################################################################
 # Alarm notification delivery
 #
 # An alarm with no action satisfies the Vanta test but alerts no one, so alarm
-# state changes publish to an SNS topic. Subscribe your team via
-# alarm_email_addresses in terraform.tfvars (each address must click the
-# confirmation link SNS emails it), or hang chat/PagerDuty integrations off
-# the topic later.
+# state changes publish to an SNS topic.
+#
+# Which topic depends on alarm_topic_arn. Set it and the alarms publish to a
+# topic that already exists in the account — the right answer whenever there
+# is one with a chat or paging integration hanging off it, because a topic
+# created here starts with no subscribers and stays that way until someone
+# remembers to populate alarm_email_addresses. An unsubscribed topic is the
+# failure mode this variable exists to avoid: the alarms look configured, the
+# Vanta test passes, and nothing reaches a human.
+#
+# Left empty, this module creates its own topic and subscribes
+# alarm_email_addresses to it (each address must click the confirmation link
+# SNS emails it), which keeps the template self-contained for a standalone
+# cluster.
 ################################################################################
+
+locals {
+  # Nothing to create when the caller supplied a topic.
+  create_alarm_topic = var.alarm_topic_arn == ""
+
+  # What every alarm above publishes to.
+  alarm_topic_arn = local.create_alarm_topic ? one(aws_sns_topic.alarms[*].arn) : var.alarm_topic_arn
+}
 
 # CloudWatch alarms cannot publish to an SNS topic encrypted with the
 # AWS-managed alias/aws/sns key, because that key's policy can't be edited to
 # let the CloudWatch service use it. A customer managed key with the
 # cloudwatch.amazonaws.com grants below is the AWS-documented fix:
 # https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html#compatibility-with-aws-services
+#
+# Only relevant to the topic this module creates. A caller-supplied topic
+# brings its own encryption decision, and must already let CloudWatch publish
+# to it — an unencrypted topic does by default.
 module "alarms_kms_key" {
+  count = local.create_alarm_topic ? 1 : 0
+
   source  = "terraform-aws-modules/kms/aws"
   version = "4.2.1"
 
@@ -145,14 +169,32 @@ module "alarms_kms_key" {
 }
 
 resource "aws_sns_topic" "alarms" {
+  count = local.create_alarm_topic ? 1 : 0
+
   name              = "${local.name}-alarms"
-  kms_master_key_id = module.alarms_kms_key.key_id
+  kms_master_key_id = one(module.alarms_kms_key[*].key_id)
 }
 
 resource "aws_sns_topic_subscription" "alarm_emails" {
-  for_each = toset(var.alarm_email_addresses)
+  # alarm_email_addresses only applies to the topic this module owns; on a
+  # caller-supplied topic, subscribe wherever that topic is defined.
+  for_each = local.create_alarm_topic ? toset(var.alarm_email_addresses) : toset([])
 
-  topic_arn = aws_sns_topic.alarms.arn
+  topic_arn = one(aws_sns_topic.alarms[*].arn)
   protocol  = "email"
   endpoint  = each.value
+}
+
+# The topic and its key gained a count above. Without these, adding
+# alarm_topic_arn would plan a destroy-and-recreate of both for every existing
+# consumer that leaves the variable empty, churning the topic ARN and dropping
+# confirmed email subscriptions along with it.
+moved {
+  from = aws_sns_topic.alarms
+  to   = aws_sns_topic.alarms[0]
+}
+
+moved {
+  from = module.alarms_kms_key
+  to   = module.alarms_kms_key[0]
 }

--- a/cluster/terraform.tfvars
+++ b/cluster/terraform.tfvars
@@ -27,7 +27,14 @@ create_spot_service_linked_role = true
 # Email addresses that receive CloudWatch alarm notifications, e.g. high CPU
 # on an EKS node (see cloudwatch-alarms.tf). Each address must confirm the
 # subscription email SNS sends it before notifications are delivered.
+# Ignored when alarm_topic_arn is set.
 alarm_email_addresses = []
+
+# Existing SNS topic for the CloudWatch alarms to publish to. Empty means this
+# module creates its own topic (and a customer managed KMS key for it). Point
+# it at a topic that already reaches the team — one with a chat or paging
+# integration on it — and the alarms go somewhere a human will see.
+alarm_topic_arn = ""
 
 tags_git_repo = "github.com/devopscoop/project1-dev"
 # AWS VPCs require a primary IPv4 CIDR even when using IPv6. The IPv6 CIDR is Amazon-provided.

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -2,7 +2,11 @@
 
 variable "alarm_email_addresses" {
   type        = list(string)
-  description = "Email addresses subscribed to the CloudWatch alarms SNS topic (cloudwatch-alarms.tf). Each address must confirm the subscription email SNS sends it before notifications are delivered."
+  description = "Email addresses subscribed to the CloudWatch alarms SNS topic (cloudwatch-alarms.tf). Each address must confirm the subscription email SNS sends it before notifications are delivered. Ignored when alarm_topic_arn is set — subscribe on the existing topic instead."
+}
+variable "alarm_topic_arn" {
+  type        = string
+  description = "ARN of an existing SNS topic for CloudWatch alarms to publish to (cloudwatch-alarms.tf). Set this when the account already runs a notification topic wired to Slack/PagerDuty, so these alarms land where the team already looks. Empty means this module creates its own topic, plus a customer managed KMS key for it, and subscribes alarm_email_addresses."
 }
 variable "bucket" {
   type        = string


### PR DESCRIPTION
Adds an `alarm_topic_arn` variable so the CloudWatch alarms in `cluster/cloudwatch-alarms.tf` can publish to an SNS topic that already exists in the account, instead of one this module creates.

## Why

This module creates its own `<cluster>-alarms` topic and subscribes `alarm_email_addresses` to it. `alarm_email_addresses` defaults to `[]`, so out of the box the topic is created with **no subscribers**. The alarms look configured, the Vanta tests they exist for pass, and nothing reaches a human.

That failure mode is quiet and it is real. In one cluster:

- the node CPU alarm went ALARM → OK three times over three consecutive weeks, 10–20 minutes each, and nobody was notified
- meanwhile every *other* CloudWatch alarm in that account — none of them created by this module — reached Slack via the account's own ops topic, which has an AWS Chatbot integration on it

So the module was the only thing in the account routing alarms somewhere nobody was looking, purely because it insists on owning the topic.

## What changes

| `alarm_topic_arn` | Behaviour |
|---|---|
| `""` (default in `terraform.tfvars`) | unchanged — module creates the topic + KMS key and subscribes `alarm_email_addresses` |
| set to an ARN | alarms publish there; module creates no topic, no KMS key, no subscriptions |

The topic and its KMS key become conditional, which changes their resource addresses. Both get `moved` blocks — without them, every existing consumer that leaves the variable empty would plan a destroy-and-recreate of the topic, churning its ARN and dropping any confirmed email subscriptions.

## ⚠️ Migration: repoint any alarms this module doesn't own

`aws_sns_topic.alarms` now has a `count`, so **every** reference to it must go through an instance key. This PR repoints the two alarms the module ships, but a consumer that has added its own alarms in `cluster/` — a file this template doesn't know about — has to repoint those too:

```diff
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
```

`local.alarm_topic_arn` is the right target rather than `aws_sns_topic.alarms[0].arn`: it resolves to the caller-supplied topic when `alarm_topic_arn` is set, and to the module's own topic when it isn't.

This is not hypothetical — it broke the first subtree consumer to pull the change, which carries one extra environment-specific alarm. The failure is loud and lands at `tofu validate`, before any plan or apply:

```
Error: Missing resource instance key
  Because aws_sns_topic.alarms has "count" set, its attributes must be
  accessed on specific instances.
```

Worth noting the alternative was considered and rejected: leaving the topic unconditional would avoid this entirely, but then setting `alarm_topic_arn` would leave a permanently unused SNS topic and a billed customer managed KMS key in every cluster that overrides. A one-line fix caught by `validate` is the better trade.

## ⚠️ Breaking for subtree consumers

Per AGENTS.md, `variables.tf` carries no defaults — every value lives in tfvars. `alarm_topic_arn` is therefore **required**. Consumers that vendor `cluster/` via `git subtree` and supply values through their own `*.auto.tfvars` (rather than the template's `terraform.tfvars`) must add the variable **in the same change that pulls this in**, or `tofu plan` fails with "No value for required variable".

This is the normal cost of the no-defaults rule — every new variable behaves this way — but it's worth calling out because the alternative here would have been a silent fallback.

## A note on encryption

The KMS key exists because CloudWatch can't publish to a topic encrypted with the AWS-managed `alias/aws/sns` key. That reasoning only applies to the topic this module creates; a caller-supplied topic brings its own encryption decision and must already permit CloudWatch to publish. An unencrypted topic does by default. The comment says so at the key.

## Verification

`tofu fmt -check` and `tofu validate` both clean. No plan available — the template repo has no cluster behind it, and the `opentofu` workflow is skipped here by design.

## Related

- devopscoop/aws-eks-template#87 — corrects the Vanta ASG comment in the same file. Different hunks; the two merge independently.
- devopscoop/fluxcd-template#64 — the Karpenter side of the same investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
